### PR TITLE
Installation Problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 #python3
 #encoding: shift-jis
-from distutils.core import setup
+from setuptools import setup
 import sys
 import io
-import execjs
+version = '1.0.0'
+license = "MIT License"
 
 with io.open('README.md', encoding='ascii') as fp:
     long_description = fp.read()
@@ -18,14 +19,14 @@ setup(
         ('', 'README.md LICENSE'.split()),
     ],
     name='CoffeeScript',
-    version=execjs.__version__,
+    version=version,
     description='A bridge to the JS CoffeeScript compiler',
     long_description=long_description,
     author='Omoto Kenji',
     author_email='doloopwhile@gmail.com',
     url='https://github.com/doloopwhile/coffeescript',
-    
-    license=execjs.__license__,
+    install_requires=('pyexecjs',),
+    license=license,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
I really like your CoffeeScript and execjs libraries. I'm glad that I found someone else seems to be interested in using JavaScript with Python. Thanks for doing all of the hard work and getting these libraries created and pushed out to pypi.

I ran into a problem trying to install Python-CoffeeScript. I have a django project that I want to use CoffeeScript in and I added "CoffeeScript" to my requirements.txt. When I run "pip install -r requirements.txt" I get an error trying to install CoffeeScript because the setup.py of the Python-CoffeeScript library requires that execjs has already been installed. 

This pull request includes changing from distutils to setuptools so that the setup function can specify pyexecjs as a dependency that will also need to be installed, and I also separated the version and licence information to be independent in the CoffeeScript library.

This change allows me to list "CoffeeScript" in my requirements.txt file and automatically install CoffeeScript and pyexecjs by running "pip install -r requirements.txt".

Thanks again, let me know if you have any questions about my pull request.
