### PR TITLE
Fix for javascript not being included in the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include LICENSE
 include README.rst
-include coffeescript/coffee-script.js
+include coffeescript/coffeescript.js

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,9 @@ setup(
     packages=['coffeescript'],
     package_dir={'coffeescript': 'coffeescript'},
     package_data={
-        'coffeescript': ['coffee-script.js'],
+        'coffeescript': ['coffeescript.js'],
     },
+    zip_safe=False,
 
     long_description=long_description,
     url='https://github.com/doloopwhile/Python-CoffeeScript',


### PR DESCRIPTION
 * Also marked as non-zip safe to be safe
 * This is because get_compiler_script() uses path concatentation