### PR TITLE
Using pkg_resource to make the package zip safe

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include LICENSE
 include README.rst
-include coffeescript/coffee-script.js
+include coffeescript/coffeescript.js

--- a/coffeescript/__init__.py
+++ b/coffeescript/__init__.py
@@ -2,6 +2,8 @@
 # -*- coding: ascii -*-
 from __future__ import division, unicode_literals, print_function
 
+import pkg_resources
+
 # Copyright (c) 2011 Omoto Kenji
 # Released under the MIT license. See `LICENSE` for details.
 
@@ -47,7 +49,6 @@ __all__ = str('''
     get_compiler_script
 ''').split()
 
-import os
 import io
 import execjs
 
@@ -115,10 +116,8 @@ def get_compiler_script():
     '''returns a CoffeeScript compiler script in JavaScript.
     which is used in coffeescript.compile() and coffeescript.compile_file()
     '''
-    from os.path import dirname, join
-    filename = join(dirname(__file__), 'coffeescript.js')
-    with io.open(filename, encoding='utf8') as fp:
-        return fp.read()
+    return pkg_resources.resource_string(
+        'coffeescript', 'coffeescript.js').decode('utf-8')
 
 
 def get_runtime():

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,9 @@ setup(
     packages=['coffeescript'],
     package_dir={'coffeescript': 'coffeescript'},
     package_data={
-        'coffeescript': ['coffee-script.js'],
+        'coffeescript': ['coffeescript.js'],
     },
+    zip_safe=False,
 
     long_description=long_description,
     url='https://github.com/doloopwhile/Python-CoffeeScript',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     package_data={
         'coffeescript': ['coffeescript.js'],
     },
-    zip_safe=False,
+    zip_safe=True,
 
     long_description=long_description,
     url='https://github.com/doloopwhile/Python-CoffeeScript',


### PR DESCRIPTION
This is in addition to the previous change request (I branched from it), and this should make the package work even if people install it via "python setup.py install"